### PR TITLE
RUN-2699 exporting Target fields to use forked repo in hcom-login

### DIFF
--- a/client/azure.go
+++ b/client/azure.go
@@ -110,7 +110,7 @@ type azureRetriever struct {
 func (r *azureRetriever) RetrieveUserDetails(target Target, authInfo api.AuthInfo) (*UserInfo, error) {
 	jwt, err := jws.ParseJWT([]byte(authInfo.Token))
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse user token for %s: %v", target.Name(), err)
+		return nil, fmt.Errorf("failed to parse user token for %s: %v", target.TargetName(), err)
 	}
 
 	if jwt.Claims().Get("unique_name") != nil {
@@ -167,7 +167,7 @@ func (r *azureRetriever) RetrieveClusterDetailsAndAuthTokens(target Target) (*Ta
 }
 
 func (r *azureRetriever) GetAuthInfo(config *api.Config, target Target) *api.AuthInfo {
-	authInfo := config.AuthInfos[target.Name()]
+	authInfo := config.AuthInfos[target.TargetName()]
 	if authInfo == nil || authInfo.Token == "" {
 		return nil
 	}

--- a/client/config.go
+++ b/client/config.go
@@ -230,7 +230,7 @@ func groupTargetsByProvider(targetEntries map[string]*TargetEntry, defaultGroup 
 			targetEntryGroups = []string{""}
 		}
 
-		target := Target{name: key, targetEntry: *targetEntry, providerType: providerType}
+		target := Target{Name: key, TargetEntry: *targetEntry, ProviderType: providerType}
 		for _, groupName := range targetEntryGroups {
 			group, ok := groupsByName[groupName]
 			if !ok {

--- a/client/config_snapshot.go
+++ b/client/config_snapshot.go
@@ -36,8 +36,8 @@ func (t *ConfigSnapshot) Targets() []Target {
 	set := make(map[string]*interface{})
 	for _, group := range t.groupsByName {
 		for _, target := range group.targets {
-			if _, ok := set[target.name]; !ok {
-				set[target.name] = nil
+			if _, ok := set[target.Name]; !ok {
+				set[target.Name] = nil
 				targets = append(targets, target)
 			}
 		}

--- a/client/group.go
+++ b/client/group.go
@@ -20,7 +20,7 @@ func (g *Group) IsDefault() bool {
 func (g *Group) Targets() map[string][]Target {
 	groupMap := make(map[string][]Target)
 	for _, target := range g.targets {
-		groupMap[target.ProviderType()] = append(groupMap[target.ProviderType()], target)
+		groupMap[target.TargetProviderType()] = append(groupMap[target.TargetProviderType()], target)
 	}
 	return getSortedTargetsByProvider(groupMap)
 }
@@ -40,7 +40,7 @@ func (g *Group) Name() string {
 //Contains returns true if it contains the target
 func (g *Group) Contains(target Target) bool {
 	for _, current := range g.targets {
-		if target.name == current.name {
+		if target.Name == current.Name {
 			return true
 		}
 	}

--- a/client/osprey.go
+++ b/client/osprey.go
@@ -58,7 +58,7 @@ func (r *ospreyRetriever) RetrieveUserDetails(target Target, authInfo api.AuthIn
 	}
 
 	if authInfo.AuthProvider.Name != "oidc" {
-		return nil, fmt.Errorf("invalid authprovider %s for target %s", authInfo.AuthProvider.Name, target.Name())
+		return nil, fmt.Errorf("invalid authprovider %s for target %s", authInfo.AuthProvider.Name, target.TargetName())
 	}
 
 	idToken := authInfo.AuthProvider.Config["id-token"]
@@ -71,7 +71,7 @@ func (r *ospreyRetriever) RetrieveUserDetails(target Target, authInfo api.AuthIn
 
 	jwt, err := jws.ParseJWT([]byte(idToken))
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse user token for %s: %v", target.Name(), err)
+		return nil, fmt.Errorf("failed to parse user token for %s: %v", target.TargetName(), err)
 	}
 
 	user := jwt.Claims().Get("email")
@@ -129,7 +129,7 @@ func (r *ospreyRetriever) RetrieveClusterDetailsAndAuthTokens(target Target) (*T
 }
 
 func (r *ospreyRetriever) GetAuthInfo(config *api.Config, target Target) *api.AuthInfo {
-	authInfo := config.AuthInfos[target.Name()]
+	authInfo := config.AuthInfos[target.TargetName()]
 	if authInfo == nil || authInfo.AuthProvider == nil {
 		return nil
 	}

--- a/client/target.go
+++ b/client/target.go
@@ -6,45 +6,45 @@ import (
 
 // Target has the information of an TargetEntry target server
 type Target struct {
-	name         string
-	targetEntry  TargetEntry
-	providerType string
+	Name         string
+	TargetEntry  TargetEntry
+	ProviderType string
 }
 
 // Aliases returns the list of aliases of the Target alphabetically sorted
 func (m *Target) Aliases() []string {
-	sort.Strings(m.targetEntry.Aliases)
-	return m.targetEntry.Aliases
+	sort.Strings(m.TargetEntry.Aliases)
+	return m.TargetEntry.Aliases
 }
 
 // HasAliases returns true if the Target has at least one alias
 func (m *Target) HasAliases() bool {
-	return len(m.targetEntry.Aliases) > 0
+	return len(m.TargetEntry.Aliases) > 0
 }
 
 // Name returns the main name of the Target
-func (m *Target) Name() string {
-	return m.name
+func (m *Target) TargetName() string {
+	return m.Name
 }
 
 // Server returns the server of the Target
 func (m *Target) Server() string {
-	return m.targetEntry.Server
+	return m.TargetEntry.Server
 }
 
 // ProviderType returns the authentication provider of the Target
-func (m *Target) ProviderType() string {
-	return m.providerType
+func (m *Target) TargetProviderType() string {
+	return m.ProviderType
 }
 
 // CertificateAuthorityData returns the CertificateAuthorityData of the Target
 func (m *Target) CertificateAuthorityData() string {
-	return m.targetEntry.CertificateAuthorityData
+	return m.TargetEntry.CertificateAuthorityData
 }
 
 func sortTargets(targets []Target) []Target {
 	sort.Slice(targets, func(i, j int) bool {
-		return targets[i].name < targets[j].name
+		return targets[i].Name < targets[j].Name
 	})
 	return targets
 }

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -83,10 +83,10 @@ func login(_ *cobra.Command, _ []string) {
 			targetData, err := retriever.RetrieveClusterDetailsAndAuthTokens(target)
 			if err != nil {
 				if state, ok := status.FromError(err); ok && state.Code() == codes.Unauthenticated {
-					log.Fatalf("Failed to log in to %s: %v", target.Name(), state.Message())
+					log.Fatalf("Failed to log in to %s: %v", target.TargetName(), state.Message())
 				}
 				success = false
-				log.Errorf("Failed to log in to %s: %v", target.Name(), err)
+				log.Errorf("Failed to log in to %s: %v", target.TargetName(), err)
 				continue
 			}
 			updateKubeconfig(target, targetData)
@@ -99,14 +99,14 @@ func login(_ *cobra.Command, _ []string) {
 }
 
 func updateKubeconfig(target client.Target, tokenData *client.TargetInfo) {
-	err := kubeconfig.UpdateConfig(target.Name(), target.Aliases(), tokenData)
+	err := kubeconfig.UpdateConfig(target.TargetName(), target.Aliases(), tokenData)
 	if err != nil {
-		log.Errorf("Failed to update config for %s: %v", target.Name(), err)
+		log.Errorf("Failed to update config for %s: %v", target.TargetName(), err)
 		return
 	}
 	aliases := ""
 	if target.HasAliases() {
 		aliases = fmt.Sprintf(" | %s", strings.Join(target.Aliases(), " | "))
 	}
-	log.Infof("Logged in to: %s %s", target.Name(), aliases)
+	log.Infof("Logged in to: %s %s", target.TargetName(), aliases)
 }

--- a/cmd/logout.go
+++ b/cmd/logout.go
@@ -45,12 +45,12 @@ func logout(_ *cobra.Command, _ []string) {
 	success := true
 	for _, targets := range group.Targets() {
 		for _, target := range targets {
-			err = kubeconfig.Remove(target.Name())
+			err = kubeconfig.Remove(target.TargetName())
 			if err != nil {
-				log.Errorf("Failed to remove %s from kubeconfig: %v", target.Name(), err)
+				log.Errorf("Failed to remove %s from kubeconfig: %v", target.TargetName(), err)
 				success = false
 			} else {
-				log.Infof("Logged out from %s", target.Name())
+				log.Infof("Logged out from %s", target.TargetName())
 			}
 		}
 	}

--- a/cmd/targets.go
+++ b/cmd/targets.go
@@ -97,7 +97,7 @@ func displayGroup(group client.Group, listTargets bool) []string {
 				if target.HasAliases() {
 					aliases = fmt.Sprintf(" | %s", strings.Join(target.Aliases(), " | "))
 				}
-				outputLines = append(outputLines, fmt.Sprintf("    %s%s", target.Name(), aliases))
+				outputLines = append(outputLines, fmt.Sprintf("    %s%s", target.TargetName(), aliases))
 			}
 		}
 	}
@@ -117,7 +117,7 @@ func displayTargets(snapshot *client.ConfigSnapshot) []string {
 		if target.HasAliases() {
 			aliases = fmt.Sprintf(" | %s", strings.Join(target.Aliases(), " | "))
 		}
-		outputLines = append(outputLines, fmt.Sprintf("%s %s%s", highlight, target.Name(), aliases))
+		outputLines = append(outputLines, fmt.Sprintf("%s %s%s", highlight, target.TargetName(), aliases))
 	}
 	return outputLines
 }

--- a/cmd/user.go
+++ b/cmd/user.go
@@ -63,23 +63,23 @@ func user(_ *cobra.Command, _ []string) {
 
 	for _, targets := range group.Targets() {
 		for _, target := range targets {
-			retriever := retrievers[target.ProviderType()]
+			retriever := retrievers[target.TargetProviderType()]
 			authInfo := retriever.GetAuthInfo(config, target)
 			if authInfo != nil {
 				userInfo, err := retriever.RetrieveUserDetails(target, *authInfo)
 				if err != nil {
-					log.Errorf("%s: %v", target.Name(), err)
+					log.Errorf("%s: %v", target.TargetName(), err)
 				}
 				if userInfo != nil {
-					switch target.ProviderType() {
+					switch target.TargetProviderType() {
 					case client.OspreyProviderName:
-						log.Infof("%s: %s %s", target.Name(), userInfo.Username, userInfo.Roles)
+						log.Infof("%s: %s %s", target.TargetName(), userInfo.Username, userInfo.Roles)
 					default:
-						log.Infof("%s: %s", target.Name(), userInfo.Username)
+						log.Infof("%s: %s", target.TargetName(), userInfo.Username)
 					}
 				}
 			} else {
-				log.Infof("%s: none", target.Name())
+				log.Infof("%s: none", target.TargetName())
 			}
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -40,3 +40,5 @@ require (
 	k8s.io/klog v0.3.3 // indirect
 	k8s.io/utils v0.0.0-20190712204705-3dccf664f023 // indirect
 )
+
+go 1.13


### PR DESCRIPTION
The changes are exporting the fields of the Target struct of osprey to allow us to import the fields into hcom-login as part of the Dex setup to allow hcom-login to integrate osprey login. 